### PR TITLE
feat: improve prompt instructions

### DIFF
--- a/src/Interceptors/LinkedAgentsInjector.php
+++ b/src/Interceptors/LinkedAgentsInjector.php
@@ -20,6 +20,7 @@ final readonly class LinkedAgentsInjector implements PromptInterceptorInterface
     public function __construct(
         private AgentRepositoryInterface $agents,
         private SchemaMapperInterface $schemaMapper,
+        private string $agentKey = 'ask_agent',
     ) {}
 
     public function generate(
@@ -52,14 +53,16 @@ final readonly class LinkedAgentsInjector implements PromptInterceptorInterface
                         MessagePrompt::system(
                             prompt: <<<'PROMPT'
 There are agents {linked_agents} associated with you. You can ask them for help if you need it.
-Use the `ask_agent` tool and provide the agent key.
+Use the `{ask_agent_tool}` tool and provide the agent key.
 Always follow rules:
 - Don't make up the agent key. Use only the ones from the provided list.
 PROMPT,
+                            with: ['linked_agents', 'ask_agent_tool'],
                         ),
                     )
                     ->withValues(
                         values: [
+                            'ask_agent_tool' => $this->agentKey,
                             'linked_agents' => \implode(
                                 PHP_EOL,
                                 \array_map(

--- a/src/Interceptors/UserPromptInjector.php
+++ b/src/Interceptors/UserPromptInjector.php
@@ -22,10 +22,12 @@ final class UserPromptInjector implements PromptInterceptorInterface
         return $next(
             input: $input->withPrompt(
                 $input->prompt->withAddedMessage(
-                    MessagePrompt::user('{user_prompt}')
-                        ->withValues([
-                            'user_prompt' => (string) $input->userPrompt,
-                        ]),
+                    MessagePrompt::user(
+                        prompt: '{user_prompt}',
+                        with: ['user_prompt'],
+                    )->withValues([
+                        'user_prompt' => (string) $input->userPrompt,
+                    ]),
                 ),
             ),
         );


### PR DESCRIPTION
### File: src/Interceptors/LinkedAgentsInjector.php

Prompt Update: The prompt message was updated to provide clearer instructions to the agents. The new prompt includes specific guidelines on how to use the ask_agent_tool and emphasizes not to make up the agent key.

Code Changes:
```php
MessagePrompt::system(
    prompt: <<<'PROMPT'
There are agents {linked_agents} associated with you. You can ask them for help if you need it. Use the {ask_agent_tool} tool and provide the agent key. Always follow rules:  
Don't make up the agent key. Use only the ones from the provided list. PROMPT, with: ['linked_agents', 'ask_agent_tool'], ),
```

### File: src/Interceptors/InstructionGenerator.php

Prompt Update: Added a new message to specify the output format instruction. This ensures that the output format is always in the specified format (e.g., markdown).

Code Changes:
```php
MessagePrompt::system(
    prompt: 'Output format instruction: {output_format_instruction}',
    with: ['output_format_instruction'],
),
```

These changes improve the clarity and guidance provided in the prompt instructions, ensuring that agents follow the specified rules and output format.